### PR TITLE
clarify use of semicolon instead of comma for multiple values of tags (fixes #16)

### DIFF
--- a/HDM.xml
+++ b/HDM.xml
@@ -10,7 +10,7 @@
 			<label text="________________________________________"/>
 			<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 			<space/>
-			<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+			<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 			<space/>
 			<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 			<space/>
@@ -41,7 +41,7 @@
 			<label text="________________________________________"/>
 			<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (géométrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 			<space/>
-			<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe déjà, ajouter la nouvelle après une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+			<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe déjà, ajouter la nouvelle après un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 			<space/>
 			<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 			<space/>
@@ -65,7 +65,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -89,7 +89,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -112,7 +112,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -135,7 +135,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -158,7 +158,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -180,7 +180,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -202,7 +202,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -223,7 +223,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -258,7 +258,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -282,7 +282,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -306,7 +306,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -342,7 +342,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -374,7 +374,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -396,7 +396,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -419,7 +419,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -445,7 +445,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -464,7 +464,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -480,7 +480,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -506,7 +506,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -533,7 +533,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -556,7 +556,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -574,7 +574,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -592,7 +592,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -607,7 +607,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -623,7 +623,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -642,7 +642,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -658,7 +658,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -682,7 +682,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -707,7 +707,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -727,7 +727,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -752,7 +752,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -779,7 +779,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -800,7 +800,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -821,7 +821,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -841,7 +841,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -858,7 +858,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -875,7 +875,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -895,7 +895,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -913,7 +913,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -961,7 +961,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -983,7 +983,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -1006,7 +1006,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1030,7 +1030,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1055,7 +1055,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1079,7 +1079,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1095,7 +1095,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1114,7 +1114,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1129,7 +1129,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1145,7 +1145,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1161,7 +1161,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1187,7 +1187,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1212,7 +1212,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1315,7 +1315,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -1350,7 +1350,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1381,7 +1381,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1407,7 +1407,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1430,7 +1430,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1457,7 +1457,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1481,7 +1481,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1502,7 +1502,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1541,7 +1541,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1582,7 +1582,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1603,7 +1603,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1626,7 +1626,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1653,7 +1653,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -1676,7 +1676,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -1693,7 +1693,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -1732,7 +1732,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1754,7 +1754,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1775,7 +1775,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1796,7 +1796,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1814,7 +1814,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1831,7 +1831,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1855,7 +1855,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1876,7 +1876,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1900,7 +1900,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1927,7 +1927,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1943,7 +1943,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1959,7 +1959,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -1991,7 +1991,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2016,7 +2016,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2048,7 +2048,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2068,7 +2068,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2092,7 +2092,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2115,7 +2115,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2134,7 +2134,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2152,7 +2152,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2172,7 +2172,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2192,7 +2192,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2210,7 +2210,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2232,7 +2232,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2249,7 +2249,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2267,7 +2267,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2291,7 +2291,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2312,7 +2312,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2333,7 +2333,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2350,7 +2350,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2369,7 +2369,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2388,7 +2388,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2404,7 +2404,7 @@
 				<key key="amenity" value="bench"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -2437,7 +2437,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2468,7 +2468,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2497,7 +2497,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2526,7 +2526,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2564,7 +2564,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2587,7 +2587,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2607,7 +2607,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2626,7 +2626,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2648,7 +2648,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2670,7 +2670,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2691,7 +2691,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2729,7 +2729,7 @@
 <label text="________________________________________" />
 <label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 <label text=" " />
-<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 <label text=" " />
 <text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name" />
 <label text=" " />
@@ -2753,7 +2753,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2776,7 +2776,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2787,7 +2787,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2809,7 +2809,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2831,7 +2831,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2853,7 +2853,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2875,7 +2875,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2897,7 +2897,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2919,7 +2919,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2941,7 +2941,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -2963,7 +2963,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -2981,7 +2981,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3001,7 +3001,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3021,7 +3021,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3040,7 +3040,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3058,7 +3058,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3076,7 +3076,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3096,7 +3096,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3115,7 +3115,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3149,7 +3149,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3177,7 +3177,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3203,7 +3203,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3231,7 +3231,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3258,7 +3258,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3290,7 +3290,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3317,7 +3317,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3351,7 +3351,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3380,7 +3380,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3407,7 +3407,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3436,7 +3436,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3465,7 +3465,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3491,7 +3491,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3518,7 +3518,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3546,7 +3546,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3564,7 +3564,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3590,7 +3590,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3608,7 +3608,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3626,7 +3626,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3646,7 +3646,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3675,7 +3675,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3695,7 +3695,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3719,7 +3719,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3741,7 +3741,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3763,7 +3763,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3784,7 +3784,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3806,7 +3806,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3829,7 +3829,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3852,7 +3852,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3874,7 +3874,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3898,7 +3898,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3921,7 +3921,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3944,7 +3944,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3967,7 +3967,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -3988,7 +3988,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4012,7 +4012,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4035,7 +4035,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4056,7 +4056,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4078,7 +4078,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4099,7 +4099,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4122,7 +4122,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4144,7 +4144,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4165,7 +4165,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4188,7 +4188,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4212,7 +4212,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4235,7 +4235,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4257,7 +4257,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4278,7 +4278,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4301,7 +4301,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4324,7 +4324,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4345,7 +4345,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4366,7 +4366,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4398,7 +4398,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4421,7 +4421,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4444,7 +4444,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4467,7 +4467,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4495,7 +4495,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4523,7 +4523,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4548,7 +4548,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4573,7 +4573,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4613,7 +4613,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4643,7 +4643,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4663,7 +4663,7 @@
 						<label text="________________________________________"/>
 						<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 						<space/>
-						<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+						<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 						<space/>
 						<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 						<space/>
@@ -4692,7 +4692,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4714,7 +4714,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4736,7 +4736,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4756,7 +4756,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4779,7 +4779,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4799,7 +4799,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4825,7 +4825,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4848,7 +4848,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4870,7 +4870,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4891,7 +4891,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4910,7 +4910,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4931,7 +4931,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4954,7 +4954,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4976,7 +4976,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -4999,7 +4999,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5021,7 +5021,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5044,7 +5044,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5067,7 +5067,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5090,7 +5090,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5108,7 +5108,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5130,7 +5130,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5152,7 +5152,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5176,7 +5176,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5199,7 +5199,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5222,7 +5222,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5244,7 +5244,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5267,7 +5267,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5288,7 +5288,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5310,7 +5310,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5335,7 +5335,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5359,7 +5359,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5380,7 +5380,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5404,7 +5404,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5427,7 +5427,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5446,7 +5446,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5465,7 +5465,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5484,7 +5484,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5503,7 +5503,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5522,7 +5522,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5541,7 +5541,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5560,7 +5560,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5579,7 +5579,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5598,7 +5598,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5617,7 +5617,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5636,7 +5636,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5655,7 +5655,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5674,7 +5674,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5696,7 +5696,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5715,7 +5715,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5734,7 +5734,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5753,7 +5753,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5772,7 +5772,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5791,7 +5791,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5810,7 +5810,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5829,7 +5829,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5851,7 +5851,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -5870,7 +5870,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5889,7 +5889,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5908,7 +5908,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5928,7 +5928,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5947,7 +5947,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5966,7 +5966,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -5987,7 +5987,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -6006,7 +6006,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -6025,7 +6025,7 @@
 					<label text="________________________________________"/>
 					<label text="source (geometry and/or attributes)" fr.text="source (geometrique et/ou attributaire)" en.text="source (geometry and/or attributes)"/>
 					<space/>
-					<label text="if one is already existing, add new after a comma. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres une virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
+					<label text="if one is already existing, add new source after a semicolon. ex: bing;survey" fr.text="si une source existe deja, ajouter la nouvelle apres un point-virgule. ex: bing;survey" en.text="if one is already existing, add new one after a comma. ex: bing;survey"/>
 					<space/>
 					<text key="source" text="source name" fr.text="nom de la source" en.text="source name"/>
 					<space/>
@@ -6054,7 +6054,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6078,7 +6078,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6104,7 +6104,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6127,7 +6127,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6152,7 +6152,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6175,7 +6175,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6197,7 +6197,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6219,7 +6219,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6245,7 +6245,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6267,7 +6267,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6287,7 +6287,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6307,7 +6307,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6332,7 +6332,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6356,7 +6356,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6376,7 +6376,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6397,7 +6397,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6414,7 +6414,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6432,7 +6432,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6450,7 +6450,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6467,7 +6467,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6485,7 +6485,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6506,7 +6506,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6527,7 +6527,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6546,7 +6546,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6564,7 +6564,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6583,7 +6583,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6603,7 +6603,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6620,7 +6620,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6638,7 +6638,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6655,7 +6655,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6673,7 +6673,7 @@
 					<label text="________________________________________"/>
 					<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 					<space/>
-					<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+					<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 					<space/>
 					<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 					<space/>
@@ -6695,7 +6695,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6712,7 +6712,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>
@@ -6729,7 +6729,7 @@
 				<label text="________________________________________"/>
 				<label text="SOURCE (geometry and/or attributes)" fr.text="SOURCE (geometrique et/ou attributaire)" en.text="SOURCE (geometry and/or attributes)"/>
 				<space/>
-				<label text="If one is already existing, add new after a comma. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres une virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
+				<label text="If one is already existing, add new source after a semicolon. Ex: Bing;survey" fr.text="Si une source existe deja, ajouter la nouvelle apres un point-virgule. Ex: Bing;survey" en.text="If one is already existing, add new one after a comma. Ex: Bing;survey"/>
 				<space/>
 				<text key="source" text="Source name" fr.text="Nom de la source" en.text="Source name"/>
 				<space/>


### PR DESCRIPTION
see #16 for more information. 

(As yohan mentioned in #13, this could be factored better, instead of repeating the same line 200+ times. Also keep in mind that there's discussion in OSM community to only tag changesets as source= and not use source= on nodes/areas/ways (
